### PR TITLE
Environnement de dev avec docker et docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM php:7.0
+
+RUN apt-get update && apt-get install -y \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libmcrypt-dev \
+        libpng12-dev \
+        libcurl4-openssl-dev \
+    && docker-php-ext-install -j$(nproc) mysqli mcrypt gd curl \
+    && rm -rf /var/lib/apt/lists/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2'
+services:
+  web:
+    build: .
+    command: php -S 0.0.0.0:80 -t /code
+    ports:
+      - "8000:80"
+    depends_on:
+      - mariadb
+    volumes:
+      - .:/code
+  mariadb:
+    image: mariadb:10.1
+    environment:
+      MYSQL_DATABASE: nuitdebout
+      MYSQL_ROOT_PASSWORD: leurfairepeur

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ exemple: nuitdebout.fr/marseille (utilisation de répertoire statué sur loomio)
 
 > utilise un "theme" commun qui peut etre largement modifié et adapté avec ses propres liens et contenus
 
-## Utilisation de la machine virtuelle
+## Installation avec Vagrant
 
 - Installer [VirtualBox](https://www.virtualbox.org/) & [Vagrant](https://docs.vagrantup.com/v2/installation/index.html)
 - Installer Vagrant Omnibus, puis lancer la création de la machine virtuelle
@@ -37,6 +37,13 @@ $ vagrant ssh -c 'cat /var/www/nuitdebout/dump/nuitdebout_multisite.sql | mysql 
 
 
 Pour arrêter la machine virtuelle, lancer `vagrant halt`.
+
+## Installation avec docker et docker-compose
+
+1. Lancer `./script/bootstrap` et suivez les indications
+1. Aller sur [nuitdebout.dev](http://nuitdebout.dev)
+
+Pour relancer plus tard: `./script/server`
 
 ## Default pwd for admin user (temporary)
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+set -e
+
+echo "Setting up your environment..."
+
+#
+# Check for Docker
+#
+if test ! $(which docker)
+then
+  echo -n " x You need to install Docker:"
+  echo "  http://docs.docker.com/"
+  exit
+fi
+
+
+#
+# Check for docker-compose
+#
+if test ! $(which docker-compose)
+then
+  echo -n " x You need to install Docker Compose:"
+  echo "  http://docs.docker.com/compose/install/"
+  exit
+fi
+
+echo "Copying config"
+cp wp-config.php.dist-docker wp-config.php
+
+echo "Loading dump. It can take some times...."
+docker-compose run --rm mariadb mysql -hmariadb -uroot -pleurfairepeur nuitdebout < dump/nuitdebout_multisite.sql
+
+echo "Starting to get the ip"
+docker-compose up -d
+
+IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $(docker-compose ps -q web))
+echo "All done. Add to your /etc/hosts: $IP nuitdebout.dev"

--- a/script/server
+++ b/script/server
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+docker-compose up -d
+echo "Go to http://nuitdebout.dev"

--- a/wp-config.php.dist-docker
+++ b/wp-config.php.dist-docker
@@ -1,0 +1,112 @@
+<?php
+/**
+ * La configuration de base de votre installation WordPress.
+ *
+ * Ce fichier contient les réglages de configuration suivants : réglages MySQL,
+ * préfixe de table, clefs secrètes, langue utilisée, et ABSPATH.
+ * Vous pouvez en savoir plus à leur sujet en allant sur
+ * {@link http://codex.wordpress.org/fr:Modifier_wp-config.php Modifier
+ * wp-config.php}. C'est votre hébergeur qui doit vous donner vos
+ * codes MySQL.
+ *
+ * Ce fichier est utilisé par le script de création de wp-config.php pendant
+ * le processus d'installation. Vous n'avez pas à utiliser le site web, vous
+ * pouvez simplement renommer ce fichier en "wp-config.php" et remplir les
+ * valeurs.
+ *
+ * @package WordPress
+ */
+
+// ** Réglages MySQL - Votre hébergeur doit vous fournir ces informations. ** //
+/** Nom de la base de données de WordPress. */
+define('DB_NAME', 'nuitdebout');
+
+/** Utilisateur de la base de données MySQL. */
+define('DB_USER', 'root');
+
+/** Mot de passe de la base de données MySQL. */
+define('DB_PASSWORD', 'leurfairepeur');
+
+/** Adresse de l'hébergement MySQL. */
+define('DB_HOST', 'mariadb');
+
+/** Jeu de caractères à utiliser par la base de données lors de la création des tables. */
+define('DB_CHARSET', 'utf8');
+
+/** Type de collation de la base de données.
+  * N'y touchez que si vous savez ce que vous faites.
+  */
+define('DB_COLLATE', '');
+
+/**#@+
+ * Clefs uniques d'authentification et salage.
+ *
+ * Remplacez les valeurs par défaut par des phrases uniques !
+ * Vous pouvez générer des phrases aléatoires en utilisant
+ * {@link https://api.wordpress.org/secret-key/1.1/salt/ le service de clefs secrètes de WordPress.org}.
+ * Vous pouvez modifier ces phrases à n'importe quel moment, afin d'invalider tous les cookies existants.
+ * Cela forcera également tous les utilisateurs à se reconnecter.
+ *
+ * @since 2.6.0
+ */
+define('AUTH_KEY', 'bgR#8O5o}@ejO%@4J5qJ@scBEpVoENHeq;Fe|ey%Qz?!D43sy$YD7^=ouDie6rH4');
+define('SECURE_AUTH_KEY', 'O9o=:u_Y]/o:^#Q}FV67C^h?#Mb|olj-D7+C,1 {|O>X)y$ige2wyMxs*F? O[O');
+define('LOGGED_IN_KEY', '}zov(N`#}o}60xj6*P c`.O4_,T=V^G?UyZ+&[G]ri s)`jUtJ (K_9y?5F/b!X4');
+define('NONCE_KEY', 'J~gMwWQ*{3X2<^G5k&O[A#yJ>5u|4+X9col]u.HkI!SqDYOT0a0d1]cyvlj(g/vF');
+define('AUTH_SALT', 'r$9[Q`^$2WQ-U80Hq(:G=ip!TDoXR&A%-^>9-e/_!;x;atJnUNg$hOzY`pRdQ%K2');
+define('SECURE_AUTH_SALT', '?42^c#w9%=Hi1zF1ttKJJ4`8|p2U/3XS)GE.h&90wT=6F0.hsaQ+<Qa@ZH6_OeDe');
+define('LOGGED_IN_SALT', 'Fwa^3_=j_3O1([?Y|:KZ~I`^M??$=k_qe@_&?g~wm.r@cL+X o}10Z{zx?HA44U^');
+define('NONCE_SALT', 'qVJ4/C%(?V6*h/h!D-TL=FEUg?^R{:t3uS+T;)CV<5M:ARH<f%la}C-*<HNbY:<y');
+/**#@-*/
+
+/**
+ * Préfixe de base de données pour les tables de WordPress.
+ *
+ * Vous pouvez installer plusieurs WordPress sur une seule base de données
+ * si vous leur donnez chacune un préfixe unique.
+ * N'utilisez que des chiffres, des lettres non-accentuées, et des caractères soulignés!
+ */
+$table_prefix  = 'wpdb_';
+
+define('WP_ALLOW_MULTISITE', true);
+
+/**
+ * Pour les développeurs : le mode déboguage de WordPress.
+ *
+ * En passant la valeur suivante à "true", vous activez l'affichage des
+ * notifications d'erreurs pendant vos essais.
+ * Il est fortemment recommandé que les développeurs d'extensions et
+ * de thèmes se servent de WP_DEBUG dans leur environnement de
+ * développement.
+ *
+ * Pour plus d'information sur les autres constantes qui peuvent être utilisées
+ * pour le déboguage, rendez-vous sur le Codex.
+ *
+ * @link https://codex.wordpress.org/Debugging_in_WordPress
+ */
+define('WP_DEBUG', false);
+
+/* C'est tout, ne touchez pas à ce qui suit ! Bon blogging ! */
+define( 'SUNRISE', 'on' );
+
+define('MULTISITE', true);
+define('SUBDOMAIN_INSTALL', false);
+define('DOMAIN_CURRENT_SITE', 'nuitdebout.dev');
+define('PATH_CURRENT_SITE', '/');
+define('SITE_ID_CURRENT_SITE', 1);
+define('BLOG_ID_CURRENT_SITE', 1);
+
+define('WP_DEFAULT_THEME', 'nuitdeboo-child');
+define('SECRET_SYNC_WIKI', '4545sd4fgvch4556dsf');
+
+// define('ADMIN_COOKIE_PATH', '/');
+// define('COOKIE_DOMAIN', '');
+// define('COOKIEPATH', '');
+// define('SITECOOKIEPATH', '');
+
+/** Chemin absolu vers le dossier de WordPress. */
+if ( !defined('ABSPATH') )
+    define('ABSPATH', dirname(__FILE__) . '/');
+
+/** Réglage des variables de WordPress et de ses fichiers inclus. */
+require_once(ABSPATH . 'wp-settings.php');


### PR DESCRIPTION
L'environnement de dev se met en place avec `./script/bootstrap` qui
copie la bonne config, charge le dump et donne la bonne config hosts.

Pour utiliser ensuite, `./script/server`. Pour stopper `docker-compose stop`.
