### PR TITLE
Fix Vagrant install

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,8 @@ Vagrant.configure("2") do |config|
     config.vm.synced_folder "./wordpress", "/var/www/nuitdebout", id: "application", nfs: $NFS
     config.vm.synced_folder "./theme", "/var/www/nuitdebout/wp-content/themes/nuitdebout",
         id: "theme", nfs: $NFS
-    config.vm.synced_folder "./logs", "/var/log/nginx", id: "logs", nfs: $NFS
+    # TODO: Fix the nginx log synchronization
+    # config.vm.synced_folder "./logs", "/var/log/nginx", id: "logs", nfs: $NFS
 
     # Configure VirtualBox environment
     config.vm.provider :virtualbox do |v|

--- a/ansible/roles/wordpress/tasks/main.yml
+++ b/ansible/roles/wordpress/tasks/main.yml
@@ -1,12 +1,11 @@
 ---
+- include: theme.yml
+  vars:
+    dir: /vagrant/theme
+    name: nuitdebout
+
 - include: nuitdebout.yml
   vars:
     dir: /var/www/nuitdebout
     theme: nuitdebout
     theme_dir: /vagrant/theme
-
-
-- include: theme.yml
-  vars:
-    dir: /vagrant/theme
-    name: nuitdebout


### PR DESCRIPTION
ref #145
- nginx logs mounting failing
- composer install having to be done before the wordpress init
