### PR TITLE
add wp-cas-server for central auth #144

### DIFF
--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -58,5 +58,6 @@
         - contact-form-7
         - login-lockdown
         - enhanced-media-library
+        - wp-cas-server
   roles:
     - wordpress


### PR DESCRIPTION
# backdoorornobackdoor

I've tried it, the only two things:
- in settings > permalinks, change the url to `/cas/` instead of `wp-cas`
- you can select the infos passed by the plugin in the plugin settings (we want the minimal only I think)
