### PR TITLE
Create the component system

### DIFF
--- a/theme/.jshintrc
+++ b/theme/.jshintrc
@@ -7,7 +7,6 @@
   "esnext": true,
   "immed": true,
   "jquery": true,
-  "latedef": true,
   "newcap": true,
   "noarg": true,
   "node": true,

--- a/theme/assets/manifest.json
+++ b/theme/assets/manifest.json
@@ -6,6 +6,11 @@
       ],
       "main": true
     },
+    "components.js": {
+      "files": [
+        "../components/**/*.js"
+      ]
+    },
     "videojs-contrib-hls.js": {
       "files": [
         "scripts/videojs-contrib-hls.js"
@@ -30,6 +35,11 @@
     }
   },
   "config": {
-    "devUrl": "http://nuitdebout.dev"
+    "devUrl": "http://nuitdebout.dev",
+    "componentScss": {
+      "main":  "components/components.scss",
+      "sources": "components/**/*.scss",
+      "dir": "components"
+    }
   }
 }

--- a/theme/bower.json
+++ b/theme/bower.json
@@ -11,7 +11,8 @@
     "font-awesome": "fontawesome#^4.6.1",
     "snapwidget": "http://snapwidget.com/js/snapwidget.js",
     "video.js": "videojs#^5.10.1",
-    "sass-flex-mixin": "~1.0.3"
+    "sass-flex-mixin": "~1.0.3",
+    "bluebird": "^3.4.0"
   },
   "overrides": {
     "video.js": {

--- a/theme/components/BaseComponent.php
+++ b/theme/components/BaseComponent.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace Component;
+
+use Component\Common\NotDisplayableException;
+
+abstract class BaseComponent extends \WP_Widget
+{
+	/**
+	 * Name of the component. Default class name
+	 * @var string
+	 */
+	protected $componentName = null;
+
+	/**
+	 * Id of the component. Default lower case class name
+	 * @var string
+	 */
+	protected $componentId = null;
+
+	/**
+	 * Description of the components
+	 * @var string|null
+	 */
+	protected $componentDescription = null;
+
+	/**
+	 * Path to the template of the component
+	 * @var string|null
+	 */
+	protected $templatePath = null;
+
+	/**
+	 * Path to the form template of the component
+	 * @var string|null
+	 */
+	protected $formTemplatePath = 'components/Common/default_form.php';
+
+	protected $isWidget = true;
+	protected $isStatic = false;
+
+	public function __construct($options = [])
+	{
+		$reflected = new \ReflectionClass($this);
+		$this->componentName = $this->componentName ? $this->componentName : $reflected->getShortName();
+		$this->componentId = $this->componentId ? $this->componentId : strtolower($this->componentName);
+		$this->componentName = str_replace('_', ' ', $this->componentName);
+
+		if ($this->componentDescripion) {
+			$options['desription'] = __($this->componentDescription);
+		}
+
+		return parent::__construct($this->componentId, $this->componentName, $options);
+	}
+
+	/**
+	 * Get the component id
+	 * @return string
+	 */
+	public function get_id()
+	{
+		return $this->componentId;
+	}
+
+	/**
+	 * Get the path of the template component
+	 * @param array $args     Widget arguments.
+	 * @param array $instance Saved values from database
+	 * @return string
+	 */
+	protected function get_template_path($args, $instance)
+	{
+		return  $this->templatePath;
+	}
+
+
+	/**
+	 * Define the parameter to expose to the templates
+	 * @param Array $instance The instance of the widget (custom options)
+	 * @return Array
+	 */
+	protected function get_template_params($instance) {
+		return $instance;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function widget( $args, $instance )
+	{
+		try {
+			extract($this->get_template_params($instance));
+
+			echo '<div class="js-component-' . $this->get_id() . '">';
+			include(locate_template($this->get_template_path($args, $instance)));
+			echo "</div>";
+		} catch (NotDisplayableException $e) {}
+	}
+
+
+	/**
+	 * Get the path of the form template component
+	 * @param array $instance Saved values from database
+	 * @return string
+	 */
+	protected function get_form_template_path($instance)
+	{
+		return  $this->formTemplatePath;
+	}
+
+	protected function get_options()
+	{
+		return [
+			'title' => [
+				'tag' => 'input',
+				'type' => 'text',
+				'default' => 'Mon Title',
+				'label' => 'Title'
+			],
+		];
+	}
+
+	/**
+	 * Define the parameter to expose to the templates
+	 * @param Array $instance The instance of the widget (custom options)
+	 * @return Array
+	 */
+	protected function get_form_template_params($instance) {
+		$options = $this->get_options();
+		foreach ($options as $key => $option) {
+			$options[$key]['value'] = $option['default'];
+		}
+		foreach ($instance as $key => $value) {
+			$options[$key]['value'] = $value;
+		}
+		return [
+			'options' => $options,
+			'instance' => $instance
+		];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function form( $instance )
+	{
+		extract($this->get_form_template_params($instance));
+		include(locate_template($this->get_form_template_path($instance)));
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function update( $newInstance, $oldInstance )
+	{
+		return $newInstance;
+	}
+
+	public function register_as_widget()
+	{
+		if (! $this->isWidget) {
+			return;
+		}
+		register_widget('\\' . get_called_class());
+	}
+
+
+	protected function get_static_instance($instance)
+	{
+		foreach($this->get_static_options() as $name => $option) {
+			if (array_key_exists($name, $instance)) {
+				continue;
+			}
+			$optionId = 'component_'.$this->componentId . '_' . $name;
+			if (get_option($optionId)) {
+				$instance[$name] = get_option($optionId);
+				continue;
+			}
+			return $option['default'];
+		}
+		return $instance;
+	}
+
+	public function render_static($options = [])
+	{
+		$this->widget([], $this->get_static_instance($options));
+	}
+
+	protected function get_static_options()
+	{
+		return $this->get_options();
+	}
+	public function register_static($wpCustomize, $panel)
+	{
+		if (! $this->isStatic) {
+			return;
+		}
+
+		$section = 'component_'. $this->componentId;
+
+		$wpCustomize->add_section( $section, [
+			'title' => __( $this->componentName ),
+			'description' => __( $this->componentDescription ),
+			'capability' => 'edit_theme_options',
+			'panel' => $panel,
+		]);
+
+		foreach ($this->get_static_options() as $name => $option) {
+			$wpCustomize->add_setting('component_'.$this->componentId . '_' . $name, [
+				'type' => 'theme_mod',
+				'capability' => 'edit_theme_options',
+				'default' => $option['default'],
+			]);
+
+			$wpCustomize->add_control( 'component_'.$this->componentId . '_' . $name, [
+				'type' => $option['type'],
+				'label' => __($option['label']),
+				'section' => $section,
+			]);
+		}
+	}
+
+
+}

--- a/theme/components/Common/NotDisplayableException.php
+++ b/theme/components/Common/NotDisplayableException.php
@@ -1,0 +1,7 @@
+<?php
+namespace Component\Common;
+
+class NotDisplayableException extends \RuntimeException
+{
+
+}

--- a/theme/components/Common/components.js
+++ b/theme/components/Common/components.js
@@ -1,0 +1,20 @@
+(function($) {
+  $.onComponentReady = onComponentReady;
+
+  function onComponentReady(componentId) {
+    return new Promise(function(success, error) {
+
+      // @todo fix never called
+      //$(document).ready(function() {
+      var $component = $('.js-component-' + componentId);
+
+      if (!$component.length) {
+        return error();
+      }
+
+      success($component);
+      //});
+    });
+  }
+
+})(jQuery);

--- a/theme/components/Common/default_form.php
+++ b/theme/components/Common/default_form.php
@@ -1,0 +1,25 @@
+<?php foreach ($options as $name => $option) : ?>
+	<p>
+		<label for="<?php echo $this->get_field_name( $name ) ?>">
+			<?php _e( $option['label'] ); ?>
+		</label>
+
+		<?php if (! $option['tag'] || $option['tag'] === 'input') : ?>
+			<?php if ($option['type'] === 'checkbox') : ?>
+				<input 	id="<?php echo $this->get_field_id( $name ) ?>"
+						  type="checkbox" value="true"
+					<?php if($option['value']) : ?> checked="checked" <?php endif; ?>
+						  name="<?php echo $this->get_field_name( $name ) ?>"
+					/>
+
+			<?php else : ?>
+				<input 	class="widefat"
+						  id="<?php echo $this->get_field_id( $name ) ?>"
+						  name="<?php echo $this->get_field_name( $name ) ?>"
+						  type="<?php echo $option['type'] ? $option['type'] : 'text'; ?>"
+						  value="<?php echo esc_attr( $option['value'] ); ?>"
+					/>
+			<?php endif; ?>
+		<?php endif; ?>
+	</p>
+<?php endforeach; ?>

--- a/theme/components/components.scss
+++ b/theme/components/components.scss
@@ -1,0 +1,8 @@
+@import '../assets/styles/common/variables';
+@import "../bower_components/bootstrap-sass/assets/stylesheets/bootstrap/_variables.scss";
+@import "../bower_components/bootstrap-sass/assets/stylesheets/bootstrap/_mixins.scss";
+
+/* Do not remove this comments bellow. It's the markers used by gulp-inject to inject
+   all your sass files automatically */
+// injector
+// endinjector

--- a/theme/components/register_component.php
+++ b/theme/components/register_component.php
@@ -1,0 +1,49 @@
+<?php
+$componentClasses = [
+];
+
+/** @var \Component\BaseComponent[] $components */
+$components = [];
+
+function instanciate_components() {
+	global $componentClasses;
+	global $components;
+	foreach ($componentClasses as $componentClass) {
+		$reflected = new \ReflectionClass($componentClass);
+		$component = $reflected->newInstance();
+		$components[$component->get_id()] = $component;
+	}
+}
+add_action('after_setup_theme', 'instanciate_components');
+
+
+function register_modules_as_widget () {
+	global $components;
+	foreach ($components as $component) {
+		$component->register_as_widget();
+	}
+}
+add_action('widgets_init','register_modules_as_widget');
+
+function register_components_as_static($wpCustomize) {
+	$wpCustomize->add_panel( 'components', [
+		'title' => __( 'Components' ),
+		'description' => __('Configuration des différents composants'),
+	]);
+
+	global $components;
+	foreach ($components as $component) {
+		$component->register_static($wpCustomize, 'components');
+	}
+}
+add_action( 'customize_register', 'register_components_as_static' );
+
+
+function the_component($id, $options = []) {
+	global $components;
+	$component = $components[$id];
+	if (! $component) {
+		return;
+	}
+	$component->render_static($options);
+}

--- a/theme/composer.json
+++ b/theme/composer.json
@@ -19,6 +19,12 @@
   "keywords": [
     "wordpress"
   ],
+  "autoload": {
+    "psr-4": {
+      "NuitDebout\\": ".",
+      "Component\\": "./components"
+    }
+  },
   "support": {
     "issues": "https://github.com/roots/sage/issues",
     "forum": "https://discourse.roots.io/"

--- a/theme/functions.php
+++ b/theme/functions.php
@@ -29,6 +29,7 @@ $sage_includes = [
 	'lib/nuitdebout/homepage.php',
 	'lib/openagenda.php',
 	'lib/nuitdebout/periscope.php',
+	'components/register_component.php',
 ];
 
 foreach ($sage_includes as $file) {

--- a/theme/gulpfile.js
+++ b/theme/gulpfile.js
@@ -21,6 +21,7 @@ var sourcemaps   = require('gulp-sourcemaps');
 var uglify       = require('gulp-uglify');
 var iconfont     = require('gulp-iconfont');
 var consolidate  = require('gulp-consolidate');
+var inject       = require('gulp-inject');
 
 // See https://github.com/austinpray/asset-builder
 var manifest = require('asset-builder')('./assets/manifest.json');
@@ -168,7 +169,7 @@ var writeToManifest = function(directory) {
 // `gulp styles` - Compiles, combines, and optimizes Bower CSS and project CSS.
 // By default this task will only log a warning if a precompiler error is
 // raised. If the `--production` flag is set: this task will fail outright.
-gulp.task('styles', ['wiredep'], function() {
+gulp.task('styles', ['wiredep', 'style:component'], function() {
   var merged = merge();
   manifest.forEachDependency('css', function(dep) {
     var cssTasksInstance = cssTasks(dep.name);
@@ -279,6 +280,8 @@ gulp.task('watch', ['build'], function() {
   gulp.watch([path.source + 'fonts/**/**'], ['fonts']);
   gulp.watch([path.source + 'socialIcons/*.svg'], ['font-socialIcons']);
   gulp.watch([path.source + 'images/**/*'], ['images']);
+  gulp.watch([config.componentScss.sources], ['style:component']);
+  gulp.watch(['components/**/*.js'], ['jshint', 'scripts']);
   gulp.watch(['bower.json', 'assets/manifest.json'], ['build']);
 });
 
@@ -310,4 +313,41 @@ gulp.task('wiredep', function() {
 // `gulp` - Run a complete build. To compile for production run `gulp --production`.
 gulp.task('default', ['clean'], function() {
   gulp.start('build');
+});
+
+
+gulp.task('style:component', ['wiredep'], function() {
+  var sassOptions = {
+    outputStyle: 'nested', // libsass doesn't support expanded yet
+    precision: 10,
+    includePaths: ['.'],
+    errLogToConsole: !enabled.failStyleTask
+  };
+
+  var injectFiles = gulp.src([
+    config.componentScss.sources,
+    '!' + config.componentScss.main
+  ], { read: false });
+
+  var injectOptions = {
+    transform: function(filePath) {
+      filePath = filePath.replace(config.componentScss.dir + '/', '');
+      return '@import "' + filePath + '";';
+    },
+    starttag: '// injector',
+    endtag: '// endinjector',
+    addRootSlash: false
+  };
+
+  return gulp.src(config.componentScss.main)
+    .pipe(inject(injectFiles, injectOptions))
+    .pipe(sourcemaps.init())
+    .pipe(sass(sassOptions))
+    .pipe(autoprefixer())
+    .pipe(cssNano())
+    .pipe(gulp.dest('dist/styles'))
+    .pipe(browserSync.reload({ stream: true }))
+    .pipe(sourcemaps.write('.', {
+      sourceRoot: 'assets/styles/'
+    }));
 });

--- a/theme/lib/setup.php
+++ b/theme/lib/setup.php
@@ -138,6 +138,7 @@ function display_sidebar() {
  */
 function assets() {
   wp_enqueue_style('sage/css', Assets\asset_path('styles/main.css'), false, null);
+  wp_enqueue_style('components/css', Assets\asset_path('styles/components.css'), false, null);
 
   if (is_single() && comments_open() && get_option('thread_comments')) {
     wp_enqueue_script('comment-reply');
@@ -145,6 +146,7 @@ function assets() {
 
   wp_enqueue_script('underscore');
   wp_enqueue_script('sage/js', Assets\asset_path('scripts/main.js'), ['jquery'], null, true);
+  wp_enqueue_script('components/js', Assets\asset_path('scripts/components.js'), ['jquery'], null, true);
 
   if ( is_home() ) {
   wp_enqueue_script('videojs-contrib-hls', Assets\asset_path('scripts/videojs-contrib-hls.js'), ['jquery'], null, true);

--- a/theme/package.json
+++ b/theme/package.json
@@ -39,6 +39,7 @@
     "gulp-flatten": "0.1.1",
     "gulp-iconfont": "^6.0.0",
     "gulp-if": "^1.2.5",
+    "gulp-inject": "^4.1.0",
     "gulp-imagemin": "^2.3.0",
     "gulp-jshint": "^1.11.2",
     "gulp-less": "^3.0.3",


### PR DESCRIPTION
J'ai mis en place un système de composant, en reprenant ce que j'avais fait à l'origine pour les module.
Je pense que ça ne fait pas de mal de commencer à architecturer un peu le truc. Le thème grossi et je commence à avoir du mal à m'y retrouver. Je détaille un peu pour éviter les questions et les débats.

Le dossier `component` à le même rôle que dans l'architexcture classique `component`, `domain`, `framework`. Il continent tous les composants qui pourrait être utilisé dans un projet Wordpress différent.

Pour ce genre de composant, la logique, la configuration,le template, le style et le javascript sont fortement couplés. Ça n'a pas de sens de les séparer et ça nous oblige à chercher tous les dossier. Du coup j'ai fait en sorte de pouvoir tout rassembler.

En héritant de `BaseComponent` vous pouvez utiliser votre composant en tant que widget ou l'afficher directement dans un template.

La configuration se fait grâce à la méthode `get_options` qui sert pour la configuration en tant que widget et/ou dans le panneau de personnalisation du thème de l'admin. Les mêmes méthodes sont appelé quelque soit la manière dont il est affiché.

Pour voir un exemple, vous pouvez regarder [la navbar](https://github.com/nuitdebout/wordpress/pull/176/commits/ec72371e67f0e46a85df1e46b73a5c0db9d007b1);
