### PR TITLE
Refonte de la page villes (version moche)

### DIFF
--- a/theme/assets/scripts/main.js
+++ b/theme/assets/scripts/main.js
@@ -206,11 +206,65 @@ function nuitdebout_getDate(element) {
           $('#current-actions').find('span:last-child').text(featuredEvents[0].text);
         }
 
-
-
       },
       finalize: function() {
         // JavaScript to be fired on the home page, after the init JS
+      }
+    },
+    'page_template_page_villes': {
+      init: function() {
+
+        var $container = $('.cities-container');
+        var $loader = $container.find('.loader');
+        var $details = $container.find('.nd-js-city-details');
+
+        var renderCity = function(city) {
+          $details.empty();
+          $loader.show();
+          var data = {
+            'action': 'cities_api_render_city_details',
+            'id': city.page_id
+          };
+          $.get(WP.ajaxURL, data).then(function(html) {
+            $loader.hide();
+            $details.html(html);
+          });
+        };
+
+        $container.find('.nd-js-city-search-form').on('submit', function(e) {
+          e.preventDefault();
+          return false;
+        });
+
+        $container.find('[data-page-id]').on('click', function(e) {
+          e.preventDefault();
+          var city = {
+            page_id: $(this).data('page-id')
+          };
+          renderCity(city);
+        });
+
+        var data = {
+          'action': 'cities_api_search'
+        };
+        $.getJSON(WP.ajaxURL, data).then(function(cities) {
+
+          cities = cities.map(function(city) {
+            return {
+              value: city.name,
+              data: city
+            };
+          });
+
+          $('#ajax-example').autocomplete({
+            lookup: cities,
+            onSelect: function (suggestion) {
+              renderCity(suggestion.data);
+            }
+          });
+
+        });
+
       }
     },
     // About us page, note the change from about-us to about_us.

--- a/theme/assets/styles/common/_global.scss
+++ b/theme/assets/styles/common/_global.scss
@@ -7,7 +7,8 @@ a:active {
 .content {
 }
 
-body.sidebar-primary {
+body.sidebar-primary,
+body.page:not(.home) {
   .main,
   .sidebar {
     padding-top: 50px;

--- a/theme/assets/styles/common/_global.scss
+++ b/theme/assets/styles/common/_global.scss
@@ -70,3 +70,10 @@ body.page:not(.home) {
 iframe{
   overflow:hidden;
 }
+
+.autocomplete-suggestions { border: 1px solid #999; background: #FFF; overflow: auto; }
+.autocomplete-suggestion { padding: 2px 5px; white-space: nowrap; overflow: hidden; }
+.autocomplete-selected { background: #F0F0F0; }
+.autocomplete-suggestions strong { font-weight: normal; color: #3399FF; }
+.autocomplete-group { padding: 2px 5px; }
+.autocomplete-group strong { display: block; border-bottom: 1px solid #000; }

--- a/theme/assets/styles/common/_global.scss
+++ b/theme/assets/styles/common/_global.scss
@@ -16,10 +16,6 @@ body.page:not(.home) {
   }
 }
 
-body.home {
-  background: $gray-lighter;
-}
-
 .mg-top0 {
   margin-top: 0;
 }

--- a/theme/assets/styles/layouts/_pages.scss
+++ b/theme/assets/styles/layouts/_pages.scss
@@ -23,3 +23,18 @@
     @extend .img-responsive;
   }
 }
+
+body {
+  &.page-template-page-villes {
+    #results {
+      .panel {
+        .list-group-item > i:before {
+          vertical-align: middle;
+          font-size: 18px;
+          line-height: 1;
+          margin-right: 5px;
+        }
+      }
+    }
+  }
+}

--- a/theme/assets/styles/layouts/_pages.scss
+++ b/theme/assets/styles/layouts/_pages.scss
@@ -1,7 +1,8 @@
 .page-header {
-  padding-bottom: 0;
-  margin: 0;
-  border-bottom: none;
+  h1, h2, h3 {
+    font-family: Roboto;
+    font-weight: bold;
+  }
 }
 
 .page {

--- a/theme/assets/styles/main.scss
+++ b/theme/assets/styles/main.scss
@@ -32,6 +32,8 @@
 @import "pages/_frontpage";
 @import "pages/_frontpage_social";
 @import "pages/_periscope";
+@import "pages/_villes";
 
 // For a strange reason, video-js.css screws the fonts when included via bower:scss
 @import "../../bower_components/video.js/dist/video-js.css";
+@import "../../bower_components/SpinKit/css/spinkit.css";

--- a/theme/assets/styles/pages/_frontpage.scss
+++ b/theme/assets/styles/pages/_frontpage.scss
@@ -197,13 +197,19 @@ iframe {
 
 
 .news-container {
-
+  @extend .row;
+  background-color: $gray-lighter;
   h2 {
     @include title-font;
   }
 
   h3 {
     font-family: Roboto;
+  }
+
+  > .section {
+    padding-left: 15px;
+    padding-right: 15px;
   }
 }
 
@@ -346,7 +352,6 @@ $news-headline-size: 360px !default;
   display: flex;
   flex-wrap: wrap;
   align-items: stretch;
-  margin-bottom: 15px;
 }
 .external-media-link {
   flex-grow: 1;

--- a/theme/assets/styles/pages/_villes.scss
+++ b/theme/assets/styles/pages/_villes.scss
@@ -1,0 +1,22 @@
+.cities-container {
+  .loader {
+    display: none;
+  }
+  .affix {
+    @media (min-width: $screen-sm-min) {
+      top: 20px;
+    }
+    @media (min-width: $screen-lg-min) {
+      width: 360px;
+    }
+    @media (min-width: $screen-md-min) and (max-width: $screen-md-max) {
+      width: 293.33px;
+    }
+    @media (min-width: $screen-sm-min) and (max-width: $screen-sm-max) {
+      width: 220px;
+    }
+    @media (max-width: $screen-xs-max) {
+      position: static !important;
+    }
+  }
+}

--- a/theme/bower.json
+++ b/theme/bower.json
@@ -11,7 +11,9 @@
     "font-awesome": "fontawesome#^4.6.1",
     "video.js": "videojs#^5.10.1",
     "sass-flex-mixin": "~1.0.3",
-    "bluebird": "^3.4.0"
+    "bluebird": "^3.4.0",
+    "devbridge-autocomplete": "^1.2.24",
+    "SpinKit": "^1.2.5"
   },
   "overrides": {
     "video.js": {
@@ -24,6 +26,9 @@
         "scss/font-awesome.scss",
         "fonts/*"
       ]
+    },
+    "SpinKit": {
+      "main": []
     },
     "bootstrap-sass": {
       "main": [

--- a/theme/components/Navbar/navbar.scss
+++ b/theme/components/Navbar/navbar.scss
@@ -11,6 +11,8 @@
   padding: 0 10px;
   position: relative;
 
+  border-bottom: 1px solid $gray-light;
+
   .nd-navbar__item {
     display: inline-block;
     min-width: 150px;

--- a/theme/functions.php
+++ b/theme/functions.php
@@ -24,6 +24,7 @@ $sage_includes = [
 	'lib/customizer.php', // Theme customizer
 
 	'acf/acf_options.php',
+	'lib/nuitdebout/cities.php',
 	'lib/nuitdebout/homepage.php',
 	'lib/nuitdebout/openagenda.php',
 	'lib/nuitdebout/periscope.php',

--- a/theme/lib/nuitdebout/cities.php
+++ b/theme/lib/nuitdebout/cities.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace NuitDebout\Wordpress\Cities;
+
+function hydrate_city($city_page)
+{
+	$fields = get_fields($city_page->ID);
+
+	$other_links = [];
+	if (!empty($fields['city_external_links'])) {
+		$other_links = explode(PHP_EOL, $fields['city_external_links']);
+	}
+
+	return [
+		'name' => $city_page->post_title,
+		'official_website' => $fields['city_official_website'],
+		'facebook_url' => $fields['facebook_page_url'],
+		'twitter_url' => $fields['twitter_page_url'],
+		'wiki_url' => $fields['wiki_page_url'],
+		'coordinates' => $fields['city_coordinates'],
+		'gathering_details' => $fields['city_gathering_details'],
+		'other_links' => $other_links,
+		'page_id' => $city_page->ID,
+	];
+}
+
+function get_cities()
+{
+	$cities = [];
+	if ($city_pages = get_pages(['child_of' => 17, 'post_type' => 'page', 'post_status' => 'publish'])) {
+	    foreach ($city_pages as $city_page) {
+	    	$cities[] = hydrate_city($city_page);
+	    }
+	}
+
+	return $cities;
+}
+
+function find_city($page_id)
+{
+	if ($city_page = get_page($page_id)) {
+
+		return hydrate_city($city_page);
+	}
+
+	return null;
+}
+
+function ajax_search_action()
+{
+	$q = $_GET['q'];
+
+	$cities = get_cities();
+	if (!empty($q)) {
+		$cities = array_filter($cities, function($city) use ($q) {
+			return false !== strpos(strtolower($city['name']), strtolower($q));
+		});
+	}
+
+	echo json_encode($cities);
+	exit;
+};
+
+add_action('wp_ajax_cities_api_search', __NAMESPACE__ . '\\ajax_search_action');
+add_action('wp_ajax_nopriv_cities_api_search', __NAMESPACE__ . '\\ajax_search_action');
+
+function ajax_find_action()
+{
+	$page_id = $_GET['id'];
+
+	if ($city = find_city($page_id)) {
+		echo json_encode($city);
+		exit;
+	}
+
+	// TODO Send HTTP 404
+};
+
+add_action('wp_ajax_cities_api_find', __NAMESPACE__ . '\\ajax_find_action');
+add_action('wp_ajax_nopriv_cities_api_find', __NAMESPACE__ . '\\ajax_find_action');
+
+function ajax_render_city_details_action()
+{
+	$page_id = $_GET['id'];
+
+	if ($city = find_city($page_id)) {
+		include locate_template('templates/module-city_details.php');
+		exit;
+	}
+
+	// TODO Send HTTP 404
+}
+
+add_action('wp_ajax_cities_api_render_city_details', __NAMESPACE__ . '\\ajax_render_city_details_action');
+add_action('wp_ajax_nopriv_cities_api_render_city_details', __NAMESPACE__ . '\\ajax_render_city_details_action');

--- a/theme/lib/setup.php
+++ b/theme/lib/setup.php
@@ -120,11 +120,7 @@ function display_sidebar() {
     // @link https://codex.wordpress.org/Conditional_Tags
     is_404(),
     is_main_site() && is_front_page(),
-    is_page_template('page-globaldebout.php'),
-    is_page_template('page-list-subpages.php'),
-    is_page_template('page-periscope.php'),
-    is_page_template('page-ville.php'),
-    is_page_template('page-villes.php'),
+    is_page(),
     !is_active_sidebar('sidebar-primary'),
   ]);
 

--- a/theme/page-villes.php
+++ b/theme/page-villes.php
@@ -7,57 +7,93 @@
  * @since Twenty Fourteen 1.0
  */
 
-/**
- * @todo move the logic
- */
-$page = get_page_by_name('Liste des villes');
-$pageTitle = apply_filters('the_title',$page->post_title);
-$args = array(
-		'child_of' => $page->ID,
-		'post_type' => 'page',
-		'post_status' => 'publish'
-);
-$pages_sub = get_pages($args);
-$citiesByLetter = [];
-if($pages_sub){
-	foreach ( $pages_sub as $p ) {
-		$content = apply_filters('the_content',$p->post_content);
-		$title = apply_filters('the_title',$p->post_title);
-		$url = esc_url( get_permalink($p->ID) );
-        $letter = $title[0];
-        $letter = htmlentities($letter) === '' ? 'E' : $letter;
+use NuitDebout\Wordpress\Cities;
 
-        if (! $citiesByLetter[$letter]) {
-            $citiesByLetter[$letter] = [];
-        }
+?>
 
-        $citiesByLetter[$letter][] = [
-            'url' => $url,
-            'title' => $title
-        ];
+<?php $cities = Cities\get_cities(); ?>
+
+<?php
+$cities_by_letter = [];
+foreach ($cities as $city) {
+    $letter = $city['name'][0];
+    // hack for the É
+    $letter = htmlentities($letter) === '' ? 'E' : $letter;
+
+    if (! $cities_by_letter[$letter]) {
+        $cities_by_letter[$letter] = [];
     }
+    $cities_by_letter[$letter][] = $city;
 }
 ?>
 
-<section class="section list-towns">
-    <h2 class="section__title">Liste des villes</h2>
-    <div class="section__content">
-        <?php foreach ($citiesByLetter as $letter => $cities) : ?>
-            <h3><?php echo $letter; ?></h3>
-            <ul class="tags-list">
-                <?php foreach ($cities as $city) : ?>
-                    <li class="tag">
-                        <a href="<?php echo $city['url'] ?>"><?php echo $city['title'] ?></a>
-                    </li>
-                <?php endforeach; ?>
-            </ul>
-        <?php endforeach; ?>
-    </div>
-</section>
+<?php while (have_posts()) : the_post(); ?>
+<div class="page-header">
+	<h1 class="text-center"><?php the_title() ?></h1>
+</div>
+<?php the_content() ?>
+<?php endwhile; ?>
 
-<section class="section section--gray">
-    <h3 class="section__title">Votre ville n'est pas listée ?</h3>
-    <div class="section__actions-container">
-        <a class="primary-button" href="http://wiki.nuitdebout.fr">Ajoutez-la sur le wiki !</a>
-    </div>
-</section>
+<div class="cities-container">
+	<div class="row">
+		<div class="col-sm-4">
+			<div id="results" data-spy="affix" data-offset-top="120">
+				<form class="nd-js-city-search-form">
+					<label for="ajax-example">Rechercher une ville</label>
+					<div class="input-group">
+	      				<div class="input-group-addon">
+	      					<span class="glyphicon glyphicon-search" aria-hidden="true"></span>
+	      				</div>
+						<input class="form-control" type="search" id="ajax-example" class="awesomplete">
+					</div>
+				</form>
+				<nav>
+					<ul class="pagination pagination-sm">
+					<?php foreach ($cities_by_letter as $letter => $cities) : ?>
+					<li><a href="#letter-<?php echo strtolower($letter) ?>"><?php echo $letter ?></a></li>
+					<?php endforeach; ?>
+					</ul>
+				</nav>
+				<div class="loader sk-wave">
+					<div class="sk-rect sk-rect1"></div>
+					<div class="sk-rect sk-rect2"></div>
+					<div class="sk-rect sk-rect3"></div>
+					<div class="sk-rect sk-rect4"></div>
+					<div class="sk-rect sk-rect5"></div>
+				</div>
+				<div class="nd-js-city-details">
+
+				</div>
+			</div>
+		</div>
+		<div class="col-sm-8">
+			<?php foreach ($cities_by_letter as $letter => $cities) : ?>
+				<?php
+				$columns = $column = [];
+				$per_column = ceil(count($cities) / 3);
+				$i = 0;
+				foreach ($cities as $city) {
+					$column[] = $city;
+					if (count($column) >= $per_column) {
+						$columns[] = $column;
+						$column = [];
+					}
+				}
+				$columns[] = $column;
+				?>
+				<h3 id="letter-<?php echo strtolower($letter) ?>"><?php echo $letter ?></h3>
+				<div class="row">
+				<?php foreach ($columns as $column) : ?>
+					<div class="col-xs-12 col-sm-4">
+						<ul class="list-unstyled">
+						<?php foreach ($column as $city) : ?>
+							<li><a href="<?php echo get_page_link($city['page_id']) ?>" data-page-id="<?php echo $city['page_id'] ?>"><?php echo $city['name'] ?></a></li>
+						<?php endforeach; ?>
+						</ul>
+					</div>
+				<?php endforeach; ?>
+				</div>
+			<?php endforeach; ?>
+		</div>
+	</div>
+</div>

--- a/theme/templates/module-city_details.php
+++ b/theme/templates/module-city_details.php
@@ -1,0 +1,41 @@
+<div class="panel panel-info">
+
+  	<div class="panel-heading">
+  		<h3 class="panel-title"><?php echo $city['name'] ?></h3>
+  	</div>
+
+  	<?php if (!empty($city['gathering_details'])) : ?>
+  	<div class="panel-body">
+		<p><?php echo $city['gathering_details'] ?></p>
+	</div>
+	<?php endif; ?>
+
+	<ul class="list-group">
+
+		<?php if (!empty($city['official_website'])) : ?>
+		<li class="list-group-item"><a href="<?php echo $city['official_website'] ?>" target="_blank"><strong>➞ Site web officiel</strong></a></li>
+		<?php endif; ?>
+
+		<?php if (!empty($city['wiki_url'])) : ?>
+		<li class="list-group-item">
+			<i class="ic-wiki_rounded"></i> <a href="<?php echo $city['wiki_url'] ?>" target="_blank">Wiki NuitDebout</a>
+		</li>
+		<?php endif; ?>
+		<?php if (!empty($city['chat_url'])) : ?>
+		<li class="list-group-item"><a href="<?php echo $city['chat_url'] ?>" target="_blank">Chat NuitDebout</a></li>
+		<?php endif; ?>
+
+		<?php if (!empty($city['facebook_url'])) : ?>
+		<li class="list-group-item">
+			<i class="ic-facebook_rounded"></i> <a href="<?php echo $city['facebook_url'] ?>" target="_blank">Page Facebook</a>
+		</li>
+		<?php endif; ?>
+		<?php if (!empty($city['twitter_url'])) : ?>
+		<li class="list-group-item">
+			<i class="ic-twitter_rounded"></i> <a href="<?php echo $city['twitter_url'] ?>" target="_blank">Compte Twitter</a>
+		</li>
+		<?php endif; ?>
+
+	</ul>
+
+</div>

--- a/theme/templates/module-news.php
+++ b/theme/templates/module-news.php
@@ -10,7 +10,8 @@ $exclude = [];
 
 ?>
 
-<div class="news-container section section--container">
+<div class="news-container">
+<div class="section section--container">
 	<div class="row">
 		<div class="col-md-8">
 
@@ -89,4 +90,5 @@ $exclude = [];
 		</div>
 		<?php endforeach ?>
 	</div>
+</div>
 </div>


### PR DESCRIPTION
Cette PR simplifie la page villes et la transforme en une sorte de SPA. 
Ça permet juste de trouver les infos essentielles (site web, page FB/Twitter, lieu de rassemblement).
Les données proviennent des champs personnalisés des pages ville, à compléter si besoin via l'admin de WP. 

@fadomire j'ai revert 092feef3c765291e6a7ac379304a200c4f68c03e car sur les sous-sites c'est tout blanc et on ne distingue pas bien la navbar. Je ne pense pas que cette bordure de 1px soit gênante. 

J'ai évité de mettre une couleur sur le body car sur les articles c'est illisible (600c24f771df15a44c5a8fd9f1d0b06f329c93dc)
